### PR TITLE
Do not throw exception when metabill resource file does not exist.

### DIFF
--- a/metabill/project.clj
+++ b/metabill/project.clj
@@ -1,4 +1,4 @@
-(defproject jp.xcoo/metabill "0.1.4"
+(defproject jp.xcoo/metabill "0.1.4-SNAPSHOT"
   :description "Read build meta info"
   :url "https://github.com/xcoo/metabill"
   :license {:name "Apache License, Version 2.0"

--- a/metabill/project.clj
+++ b/metabill/project.clj
@@ -1,4 +1,4 @@
-(defproject jp.xcoo/metabill "0.1.3"
+(defproject jp.xcoo/metabill "0.1.4"
   :description "Read build meta info"
   :url "https://github.com/xcoo/metabill"
   :license {:name "Apache License, Version 2.0"

--- a/metabill/src/metabill/core.clj
+++ b/metabill/src/metabill/core.clj
@@ -29,7 +29,9 @@
     (if resource-file
       (try
         (edn/read-string (slurp resource-file))
-        (catch Exception _ nil))
+        (catch RuntimeException re ((binding [*out* *err*]
+                                      (println (.getMessage re)))
+                                    nil)))
       nil)))
 
 ;;; with

--- a/metabill/src/metabill/core.clj
+++ b/metabill/src/metabill/core.clj
@@ -26,7 +26,6 @@
     d))
 
 (defn- print-err [& msg]
-  (println msg)
   (binding [*out* *err*]
     (println (apply str msg))))
 

--- a/metabill/src/metabill/core.clj
+++ b/metabill/src/metabill/core.clj
@@ -25,7 +25,10 @@
     d))
 
 (defn load-build-meta-data []
-  (edn/read-string (slurp (io/resource metabill-filename))))
+  (let [resource-file (io/resource metabill-filename)]
+    (if resource-file
+      (edn/read-string (slurp resource-file))
+      nil)))
 
 ;;; with
 

--- a/metabill/src/metabill/core.clj
+++ b/metabill/src/metabill/core.clj
@@ -6,7 +6,7 @@
   (:import [java.io FileNotFoundException]))
 
 (def ^:dynamic metabill-dir-path "resources")
-(def ^:dynamic metabill-filename "metabill_err.edn")
+(def ^:dynamic metabill-filename "metabill.edn")
 
 (def build-meta
   {:time (fn []

--- a/metabill/src/metabill/core.clj
+++ b/metabill/src/metabill/core.clj
@@ -27,7 +27,9 @@
 (defn load-build-meta-data []
   (let [resource-file (io/resource metabill-filename)]
     (if resource-file
-      (edn/read-string (slurp resource-file))
+      (try
+        (edn/read-string (slurp resource-file))
+        (catch Exception _ nil))
       nil)))
 
 ;;; with


### PR DESCRIPTION
metabill loads its default result value of git hash from ``metabill.edn``.
But when metabill.edn does not exist, metabill throws exception.
This PR fix this problem as returns nil when metabill.edn does not exist.
Also, this PR returns nil when metabill.edn exists but contains illegal format edn.