### PR TITLE
Prepare metabill directory before saving meta

### DIFF
--- a/metabill/src/metabill/core.clj
+++ b/metabill/src/metabill/core.clj
@@ -22,6 +22,7 @@
 (defn save-build-meta-data []
   (let [d (make-build-meta-data)
         f (.getAbsolutePath (io/file metabill-dir-path metabill-filename))]
+    (.mkdirs (io/file metabill-dir-path))
     (spit f (pr-str d))
     d))
 


### PR DESCRIPTION
This patch prepares the metabill directory (`resources` in default) before saving the meta into it.